### PR TITLE
proposed changes for 2020, part 1

### DIFF
--- a/generator/pretalx/sotm2020.xml
+++ b/generator/pretalx/sotm2020.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xml:lang="en" xmlns="http://www.w3.org/2005/Atom"><title>State of the Map 2020 schedule updates</title><link href="https://pretalx.com/sotm2020/schedule/" rel="alternate"></link><link href="https://pretalx.com/sotm2020/schedule/feed.xml" rel="self"></link><id>https://pretalx.com/sotm2020/schedule/feed.xml</id><updated>2020-06-30T20:46:02.775444+00:00</updated><entry><title>New State of the Map 2020 schedule released (0.6)</title><link href="https://pretalx.com/sotm2020/schedule/=version=0.6" rel="alternate"></link><published>2020-06-30T20:46:02.775444+00:00</published><id>https://pretalx.com/sotm2020/schedule/=version=0.6</id><summary type="html">
+
+&lt;p&gt;
+    
+        A new State of the Map 2020 schedule has been released!
+    
+&lt;/p&gt;
+
+
+
+
+  &lt;p&gt;&lt;p&gt;We released a new schedule version! Two talks were switched to resolve a session-host-shift conflict.&lt;/p&gt;&lt;/p&gt;
+
+
+    
+
+    
+
+    
+        
+            &lt;p&gt;We had to move some talks, so if you were planning on seeing them, check their new dates or locations:&lt;/p&gt;
+            &lt;ul&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/JYWQX3/"&gt;
+                    “Trademarks &amp;amp; OSMF”
+                    
+                        by Kathleen Lu
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 3:45 p.m., Track 1 → July 5, 2020, 8 p.m., Track 2)
+                
+               &lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/KNU7L3/"&gt;
+                    “Earthquakes and OpenStreetMap”
+                    
+                        by Danijel Schorlemmer
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 8 p.m., Track 2 → July 5, 2020, 3:45 p.m., Track 1)
+                
+               &lt;/li&gt;
+                
+            &lt;/ul&gt;
+        
+    
+
+
+</summary></entry><entry><title>New State of the Map 2020 schedule released (0.5)</title><link href="https://pretalx.com/sotm2020/schedule/=version=0.5" rel="alternate"></link><published>2020-06-30T08:55:32.299778+00:00</published><id>https://pretalx.com/sotm2020/schedule/=version=0.5</id><summary type="html">
+
+&lt;p&gt;
+    
+        A new State of the Map 2020 schedule has been released!
+    
+&lt;/p&gt;
+
+
+
+
+  &lt;p&gt;&lt;p&gt;We released a new schedule version! Unfortunately, we had to cancel two talks, so we also had to move around some others to fill those gaps.&lt;/p&gt;&lt;/p&gt;
+
+
+    
+
+    
+        
+            &lt;p&gt;Sadly, we had to cancel talks:&lt;/p&gt;
+            &lt;ul&gt;
+                
+                &lt;li&gt;
+                    “Use of OSM data in formalizing informal public transport systems, case of Maputo-Mozambique”
+                    
+                        by Remígio Chilaule
+                    
+                &lt;/li&gt;
+                
+                &lt;li&gt;
+                    “Rapid Mapping of 50 Communes in Madagascar”
+                    
+                        by Seth Cochran
+                    
+                &lt;/li&gt;
+                
+            &lt;/ul&gt;
+        
+    
+
+    
+        
+            &lt;p&gt;We had to move some talks, so if you were planning on seeing them, check their new dates or locations:&lt;/p&gt;
+            &lt;ul&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/7LWKCA/"&gt;
+                    “OSM Quiz”
+                    
+                        by SotM Working Group
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 9:30 p.m. → July 5, 2020, 8:45 p.m.)
+                
+               &lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/JYWQX3/"&gt;
+                    “Trademarks &amp;amp; OSMF”
+                    
+                        by Kathleen Lu
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 8:45 p.m. → July 5, 2020, 3:45 p.m.)
+                
+               &lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/JDNTHK/"&gt;
+                    “Minutely Extracts: Tools for nimble editing and downloading”
+                    
+                        by 劉知岳
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 8:45 p.m., Track 2 → July 5, 2020, 5:15 p.m., Track 1)
+                
+               &lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/VTDQPZ/"&gt;
+                    “Closing”
+                    
+                        by SotM Working Group
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 9:50 p.m. → July 5, 2020, 9:05 p.m.)
+                
+               &lt;/li&gt;
+                
+            &lt;/ul&gt;
+        
+    
+
+
+</summary></entry><entry><title>New State of the Map 2020 schedule released (0.4)</title><link href="https://pretalx.com/sotm2020/schedule/=version=0.4" rel="alternate"></link><published>2020-06-16T19:14:04.826666+00:00</published><id>https://pretalx.com/sotm2020/schedule/=version=0.4</id><summary type="html">
+
+&lt;p&gt;
+    
+        A new State of the Map 2020 schedule has been released!
+    
+&lt;/p&gt;
+
+
+
+
+  &lt;p&gt;&lt;p&gt;We released a new schedule version! This update mostly contains minor changes like text improvements.&lt;/p&gt;&lt;/p&gt;
+
+
+
+</summary></entry><entry><title>New State of the Map 2020 schedule released (0.3)</title><link href="https://pretalx.com/sotm2020/schedule/=version=0.3" rel="alternate"></link><published>2020-05-14T19:27:11.706144+00:00</published><id>https://pretalx.com/sotm2020/schedule/=version=0.3</id><summary type="html">
+
+&lt;p&gt;
+    
+        A new State of the Map 2020 schedule has been released!
+    
+&lt;/p&gt;
+
+
+
+
+  &lt;p&gt;&lt;p&gt;We released a new schedule version! Two talks were switched to better accommodate the time zones of some of the speakers, so please check if you have to adapt your plans.&lt;/p&gt;&lt;/p&gt;
+
+
+    
+
+    
+
+    
+        
+            &lt;p&gt;We had to move some talks, so if you were planning on seeing them, check their new dates or locations:&lt;/p&gt;
+            &lt;ul&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/JDNTHK/"&gt;
+                    “Minutely Extracts: Tools for nimble editing and downloading”
+                    
+                        by 劉知岳
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 5:15 p.m., Track 1 → July 5, 2020, 8:45 p.m., Track 2)
+                
+               &lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/S8HYDT/"&gt;
+                    “Rapid Mapping of 50 Communes in Madagascar”
+                    
+                        by Seth Cochran
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 8:45 p.m., Track 2 → July 5, 2020, 5:15 p.m., Track 1)
+                
+               &lt;/li&gt;
+                
+            &lt;/ul&gt;
+        
+    
+
+
+</summary></entry><entry><title>New State of the Map 2020 schedule released (0.2)</title><link href="https://pretalx.com/sotm2020/schedule/=version=0.2" rel="alternate"></link><published>2020-05-13T20:05:31.884707+00:00</published><id>https://pretalx.com/sotm2020/schedule/=version=0.2</id><summary type="html">
+
+&lt;p&gt;
+    
+        A new State of the Map 2020 schedule has been released!
+    
+&lt;/p&gt;
+
+
+
+
+  &lt;p&gt;&lt;p&gt;We released a new schedule version! We have added some additional talks and had to move some that were already in the schedule, so please check if you have to adapt your plans.&lt;/p&gt;&lt;/p&gt;
+
+
+    
+        
+            &lt;p&gt;We have new talks!&lt;/p&gt;
+            &lt;ul&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/DVR7ME/"&gt;
+                    “Building Stronger Communities Together - the Local Chapters &amp;amp; Community Working Group”
+                    
+                &lt;/a&gt;&lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/S8HYDT/"&gt;
+                    “Rapid Mapping of 50 Communes in Madagascar”
+                    
+                &lt;/a&gt;&lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/URVEBF/"&gt;
+                    “Identify map problems in OSM by connectivity check”
+                    
+                &lt;/a&gt;&lt;/li&gt;
+                
+            &lt;/ul&gt;
+        &lt;/p&gt;
+    
+
+    
+
+    
+        
+            &lt;p&gt;We had to move some talks, so if you were planning on seeing them, check their new dates or locations:&lt;/p&gt;
+            &lt;ul&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/FZCM39/"&gt;
+                    “Meet an OpenStreetMapper”
+                    
+                        by Gregory Marler
+                    
+                    &lt;/a&gt;
+                
+                (July 4, 2020, 9:30 p.m. → July 4, 2020, 10:15 p.m.)
+                
+               &lt;/li&gt;
+                
+                &lt;li&gt;&lt;a href="/sotm2020/talk/KNU7L3/"&gt;
+                    “Earthquakes and OpenStreetMap”
+                    
+                        by Danijel Schorlemmer
+                    
+                    &lt;/a&gt;
+                
+                (July 5, 2020, 12:15 p.m., Track 1 → July 5, 2020, 8 p.m., Track 2)
+                
+               &lt;/li&gt;
+                
+            &lt;/ul&gt;
+        
+    
+
+
+</summary></entry><entry><title>New State of the Map 2020 schedule released (0.1)</title><link href="https://pretalx.com/sotm2020/schedule/=version=0.1" rel="alternate"></link><published>2020-05-02T16:07:00.203017+00:00</published><id>https://pretalx.com/sotm2020/schedule/=version=0.1</id><summary type="html">
+
+&lt;p&gt;
+    
+        The first State of the Map 2020 schedule has been released!
+    
+&lt;/p&gt;
+
+
+
+
+  &lt;p&gt;&lt;p&gt;We released our first schedule version!&lt;/p&gt;&lt;/p&gt;
+
+
+
+</summary></entry></feed>

--- a/schema/schedule.xml.xsd
+++ b/schema/schedule.xml.xsd
@@ -3,6 +3,13 @@
   <xs:element name="schedule">
     <xs:complexType>
       <xs:sequence>
+        <xs:element minOccurs="0" name="generator">
+          <xs:complexType>
+            <xs:sequence />
+            <xs:attribute type="xs:string" name="name"/>
+            <xs:attribute type="xs:string" name="version"/>
+          </xs:complexType>
+        </xs:element>
         <xs:element type="xs:string" name="version"/>
         <xs:element name="conference">
           <xs:complexType>
@@ -15,6 +22,7 @@
               <xs:element type="xs:integer" name="days" minOccurs="0"/>
               <xs:element type="duration"   name="timeslot_duration" minOccurs="0"/>
               <xs:element type="httpURI"    name="base_url" minOccurs="0"/>
+              <xs:element type="xs:string"  name="time_zone_name" minOccurs="0" maxOccurs="1"/>
             </xs:all>
           </xs:complexType>
         </xs:element>
@@ -75,7 +83,6 @@
       <xs:element type="recording" name="recording" minOccurs="0"/>
       <xs:element type="links" name="links" minOccurs="0"/>
       <xs:element type="attachments" name="attachments" minOccurs="0"/>
-      <xs:element type="httpURI" name="video_download_url" minOccurs="0"/>
       <xs:element type="httpURI" name="url" minOccurs="0"/>
     </xs:all>
     <xs:attribute name="id" type="xs:positiveInteger" use="required"/>
@@ -116,6 +123,8 @@
     <xs:all>
       <xs:element type="xs:string"  name="license"/>
       <xs:element type="xs:boolean" name="optout"/>
+      <xs:element type="httpURI" name="url" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element type="httpURI" name="link" minOccurs="0"/>
     </xs:all>
   </xs:complexType>
 


### PR DESCRIPTION
Adds
* `generator` as already used by frab and pretalx
* new field `time_zone_name` on conference https://github.com/voc/schedule/issues/69
* moves `video_download_url` to recording entity as `url` as one or multiple direct URLs to video files
* add field `link` to recording entity as url to a website displaying the recording e.g. media.ccc.de


Support for `generator` is implemented in 
* [x] frab
* [x] pretalx
* [x] voc schedule tools
* [ ] voctosched

Support for `time_zone_name` is implemented in 
* [x] https://github.com/frab/frab/issues/721
* [x] pretalx
* [x] voc schedule tools
* [x] https://github.com/EventFahrplan/EventFahrplan/pull/296 (discussion)